### PR TITLE
Change validation format for name, phone and email

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -12,16 +12,16 @@ public class Email {
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
-            + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
-    // alphanumeric and special characters
+            + "1.The email address should contain at least one character in the local part, "
+            + "consisting of letters (both uppercase and lowercase), digits, "
+            + "underscores, and certain special characters including +, &, *, and -.\n"
+            + "2. The \"@\" symbol is required to separate the local part from the domain part.\n"
+            + "3. The domain part of the email address should consist of at least one domain label, "
+            + "4. The top-level domain (TLD) of the email address should consist of letters (uppercase or lowercase) "
+            + "and have a length of between 2 and 7 characters.\n";
+
+    private static final String OWASP_EMAIL_VALIDATION = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}";
+
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
@@ -29,7 +29,7 @@ public class Email {
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    public static final String VALIDATION_REGEX = OWASP_EMAIL_VALIDATION;
 
     public final String value;
 
@@ -46,6 +46,19 @@ public class Email {
 
     /**
      * Returns if a given string is a valid email.
+     *
+     * The format of email follows the OWASP email validation rule :
+     * 1. The email address should contain at least one character in the local part,
+     *    consisting of letters (both uppercase and lowercase), digits, underscores,
+     *    and certain special characters including +, &, *, and -.
+     *
+     * 2. The "@" symbol is required to separate the local part from the domain part.
+     *
+     * 3. The domain part of the email address should consist of at least one domain label,
+     *    with each label containing letters, digits, and hyphens, and separated by periods.
+     *
+     * 4. The top-level domain (TLD) of the email address should consist of letters (uppercase or lowercase)
+     *    and have a length of between 2 and 7 characters.
      */
     public static boolean isValidEmail(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
-    private static final String SPECIAL_CHARACTERS = "+_.-";
+
+
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1.The email address should contain at least one character in the local part, "
@@ -19,17 +20,10 @@ public class Email {
             + "3. The domain part of the email address should consist of at least one domain label, "
             + "4. The top-level domain (TLD) of the email address should consist of letters (uppercase or lowercase) "
             + "and have a length of between 2 and 7 characters.\n";
-
-    private static final String OWASP_EMAIL_VALIDATION = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}";
-
-    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String OWASP_EMAIL_VALIDATION = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@"
+            + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}";
     public static final String VALIDATION_REGEX = OWASP_EMAIL_VALIDATION;
+
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces of length 64 characters, and it should not be blank";
+            "Names should only contain alphanumeric characters "
+                    + "and spaces of length 64 characters, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -38,7 +39,7 @@ public class Name {
      * the total length is not larger than 64 characters.
      */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX) && test.length() <= 64   ;
+        return test.matches(VALIDATION_REGEX) && test.length() <= 64;
     }
 
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces of length 64 characters, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -33,9 +33,12 @@ public class Name {
 
     /**
      * Returns true if a given string is a valid name.
+     *
+     * The name is only valid if the first character is not empty space and
+     * the total length is not larger than 64 characters.
      */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= 64   ;
     }
 
 

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and it should be 8 digits long";
+    public static final String VALIDATION_REGEX = "\\d{8}";
     public final String value;
 
     /**
@@ -28,6 +28,8 @@ public class Phone {
 
     /**
      * Returns true if a given string is a valid phone number.
+     *
+     * The phone number has to be 8 digits (Singapore number)
      */
     public static boolean isValidPhone(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Valid Person",
-    "phone": "9482424",
+    "phone": "94824245",
     "email": "hans@example.com",
     "address": "4th street"
   }, {

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Person with invalid name field: Ha!ns Mu@ster",
-    "phone": "9482424",
+    "phone": "94824245",
     "email": "hans@example.com",
     "address": "4th street"
   } ]

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -26,19 +26,19 @@
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
-    "phone" : "9482224",
+    "phone" : "94822224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
-    "phone" : "9482427",
+    "phone" : "94821427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "tags" : [ ]
   }, {
     "name" : "George Best",
-    "phone" : "9482442",
+    "phone" : "94828442",
     "email" : "anna@example.com",
     "address" : "4th street",
     "tags" : [ ]

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -28,7 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "12345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -42,24 +42,34 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@example.com ")); // trailing space
         assertFalse(Email.isValidEmail("peterjack@@example.com")); // double '@' symbol
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
-        assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
         assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
+        assertFalse(Email.isValidEmail("peterjack@exa..mple.com")); // domain part has two consecutive periods
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
-        assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than 2 chars
+        assertFalse(Email.isValidEmail("peterjack@example.computer")); // top level domain has more than 7 chars
+        assertFalse(Email.isValidEmail("peterjack@example.123")); // top level domain has numbers
+        assertFalse(Email.isValidEmail("peterjack@example.*-/+")); // top level domain has special characters
+        assertFalse(Email.isValidEmail("a@bc")); // minimal
+        assertFalse(Email.isValidEmail("test@localhost")); // alphabets only, no top level domain
+        assertFalse(Email.isValidEmail("123@145")); // numeric local part and domain name with no top level domain
+
+
+
+
 
         // valid email
+        assertTrue(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
+        assertTrue(Email.isValidEmail("PeterJack&1190@example.com")); // '&' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("PeterJack1190@exam-ple.com")); // hyphen in domain part
+        assertTrue(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
+        assertTrue(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -68,10 +78,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +93,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 }

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -69,8 +69,8 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345678", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -27,18 +27,22 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
+        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters and shorter than 64 characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
         assertFalse(Name.isValidName("Haliphibourous Maximilian Hippopotolosoto; "
                 + "Eater of The Five Golden Suns, "
-                + "Son of the Great Sultan Kolosomonomia")); //name longer than 64 characters
+                + "Son of the Great Sultan Kolosomonomia")); //name longer than 64 characters and special characters
+        assertFalse(Name.isValidName("Haliphibourous Maximilian Hippopotolosoto "
+                + "Eater of The Five Golden Suns "
+                + "Son of the Great Sultan Kolosomonomia")); //name longer than 64 characters and no special characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("SPONGEBOB")); // only capital letters
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names shorter than 64 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,6 +29,8 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("Haliphibourous Maximilian Hippopotolosoto; " +
+                "Eater of The Five Golden Suns, Son of the Great Sultan Kolosomonomia")); //name longer than 64 characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,8 +29,9 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
-        assertFalse(Name.isValidName("Haliphibourous Maximilian Hippopotolosoto; " +
-                "Eater of The Five Golden Suns, Son of the Great Sultan Kolosomonomia")); //name longer than 64 characters
+        assertFalse(Name.isValidName("Haliphibourous Maximilian Hippopotolosoto; "
+                + "Eater of The Five Golden Suns, "
+                + "Son of the Great Sultan Kolosomonomia")); //name longer than 64 characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -1,6 +1,9 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -1,7 +1,6 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -31,30 +30,31 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("911")); // short phone numbers
+        assertFalse(Phone.isValidPhone("124293842033123")); // long phone numbers
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("93121534")); // exactly 8 numbers
+
     }
 
     @Test
     public void equals() {
-        Phone phone = new Phone("999");
+        Phone phone = new Phone("12345678");
 
         // same values -> returns true
-        assertTrue(phone.equals(new Phone("999")));
+        assertEquals(phone, new Phone("12345678"));
 
         // same object -> returns true
-        assertTrue(phone.equals(phone));
+        assertEquals(phone, phone);
 
         // null -> returns false
-        assertFalse(phone.equals(null));
+        assertNotEquals(null, phone);
 
         // different types -> returns false
-        assertFalse(phone.equals(5.0f));
+        assertNotEquals(5.0f, phone);
 
         // different values -> returns false
-        assertFalse(phone.equals(new Phone("995")));
+        assertNotEquals(phone, new Phone("87654321"));
     }
 }

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -1,8 +1,6 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -35,6 +35,9 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
         assertFalse(Phone.isValidPhone("911")); // short phone numbers
         assertFalse(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertFalse(Phone.isValidPhone("/*-/-++")); // special characters
+        assertFalse(Phone.isValidPhone("+6589562314")); // with country code
+        assertFalse(Phone.isValidPhone("+60123931189")); // non-Singapore phone number
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("93121534")); // exactly 8 numbers

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -48,19 +48,22 @@ public class PhoneTest {
     public void equals() {
         Phone phone = new Phone("12345678");
 
-        // same values -> returns true
+        // same values 
         assertEquals(phone, new Phone("12345678"));
 
-        // same object -> returns true
+        // same object
         assertEquals(phone, phone);
 
-        // null -> returns false
+        // null
         assertNotEquals(null, phone);
 
-        // different types -> returns false
+        // primitive and Phone type
         assertNotEquals(5.0f, phone);
 
-        // different values -> returns false
+        // different type
+        assertNotEquals(new Name("apple"), phone);
+
+        // different values
         assertNotEquals(phone, new Phone("87654321"));
     }
 }

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -48,22 +48,22 @@ public class PhoneTest {
     public void equals() {
         Phone phone = new Phone("12345678");
 
-        // same values 
-        assertEquals(phone, new Phone("12345678"));
+        // same values
+        assertTrue(phone.equals(new Phone("12345678")));
 
         // same object
-        assertEquals(phone, phone);
+        assertTrue(phone.equals(phone));
 
         // null
-        assertNotEquals(null, phone);
+        assertFalse(phone.equals(null));
 
         // primitive and Phone type
-        assertNotEquals(5.0f, phone);
+        assertFalse(phone.equals(50.f));
 
         // different type
-        assertNotEquals(new Name("apple"), phone);
+        assertFalse(phone.equals(new Name("apple")));
 
         // different values
-        assertNotEquals(phone, new Phone("87654321"));
+        assertFalse(phone.equals(new Phone("87654321")));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -38,17 +38,17 @@ public class TypicalPersons {
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("94822224")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("94821427")
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
+    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("94828442")
             .withEmail("anna@example.com").withAddress("4th street").build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("84829424")
             .withEmail("stefan@example.com").withAddress("little india").build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("84824131")
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Names need to be alphabets and at most 64 characters

Phone number has to be 8 digits

Email format follows OWASP standard

Changes test case to fulfill the constraints

close #86 
