### PR TITLE
Fix bug of equals method in address

### DIFF
--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -62,6 +62,11 @@ public class Address {
             return false;
         }
 
+        // if one of the address is empty, other == this should be true
+        if (other instanceof EmptyAddress) {
+            return false;
+        }
+
         Address otherAddress = (Address) other;
         return value.equals(otherAddress.value);
     }

--- a/src/main/java/seedu/address/model/person/EmptyAddress.java
+++ b/src/main/java/seedu/address/model/person/EmptyAddress.java
@@ -5,7 +5,7 @@ package seedu.address.model.person;
  */
 public class EmptyAddress extends Address {
 
-    public static String DUMMY_VALUE_FOR_EMPTY_ADDRESS = "-";
+    public static final String DUMMY_VALUE_FOR_EMPTY_ADDRESS = "-";
 
     /**
      * Constructs an empty address object.

--- a/src/main/java/seedu/address/model/person/EmptyAddress.java
+++ b/src/main/java/seedu/address/model/person/EmptyAddress.java
@@ -4,11 +4,14 @@ package seedu.address.model.person;
  * Represents an empty address.
  */
 public class EmptyAddress extends Address {
+
+    public static String DUMMY_VALUE_FOR_EMPTY_ADDRESS = "-";
+
     /**
      * Constructs an empty address object.
      */
     public EmptyAddress() {
-        super("-");
+        super(DUMMY_VALUE_FOR_EMPTY_ADDRESS);
     }
 
     @Override

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -49,6 +49,7 @@ public class AddressTest {
     @Test
     public void equals() {
         Address address = new Address("Valid Address");
+        Address address_with_value_of_empty_address = new Address(EmptyAddress.DUMMY_VALUE_FOR_EMPTY_ADDRESS);
 
         // same values -> returns true
         assertTrue(address.equals(new Address("Valid Address")));
@@ -67,5 +68,8 @@ public class AddressTest {
 
         // empty address -> returns false
         assertFalse(address.equals(Address.EMPTY_ADDRESS));
+
+        // valid address with same value as empty address should not be equal to empty address
+        assertFalse(address_with_value_of_empty_address.equals(Address.EMPTY_ADDRESS));
     }
 }


### PR DESCRIPTION
Fixed the bug where an address with the same value of empty address will be equal to an empty address