### PR TITLE
Enhance Insurance and Make Appointment command and prefixes case insensitive

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -54,6 +54,7 @@ public class AddressBookParser {
         final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
+        // Convert all Uppercase prefixes to lowercase
         final String processedArguments = ArgumentTokenizer.preprocessArgsString(arguments);
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS_UPPER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADD_INSURANCE_UPPER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADD_TAG_UPPER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_TIME_UPPER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_UPPER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_VENUE_UPPER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_INSURANCE_UPPER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DELETE_TAG_UPPER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL_UPPER;
@@ -55,7 +58,8 @@ public class ArgumentTokenizer {
         Prefix[] uppercasePrefixes = new Prefix[] { PREFIX_NAME_UPPER, PREFIX_PHONE_UPPER,
             PREFIX_EMAIL_UPPER, PREFIX_PRIORITY_UPPER, PREFIX_TAG_UPPER, PREFIX_REMARK_UPPER,
             PREFIX_INSURANCE_UPPER, PREFIX_ADDRESS_UPPER, PREFIX_ADD_INSURANCE_UPPER,
-            PREFIX_DELETE_INSURANCE_UPPER, PREFIX_ADD_TAG_UPPER, PREFIX_DELETE_TAG_UPPER };
+            PREFIX_DELETE_INSURANCE_UPPER, PREFIX_ADD_TAG_UPPER, PREFIX_DELETE_TAG_UPPER, PREFIX_APPOINTMENT_UPPER,
+            PREFIX_APPOINTMENT_TIME_UPPER, PREFIX_APPOINTMENT_VENUE_UPPER};
 
         String processedArgs = argsString;
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -19,6 +19,11 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADD_INSURANCE = new Prefix("ai/");
     public static final Prefix PREFIX_DELETE_INSURANCE = new Prefix("di/");
     public static final Prefix PREFIX_PRIORITY = new Prefix("pr/");
+    public static final Prefix PREFIX_APPOINTMENT = new Prefix("d/");
+    public static final Prefix PREFIX_APPOINTMENT_TIME = new Prefix("t/");
+    public static final Prefix PREFIX_APPOINTMENT_VENUE = new Prefix("v/");
+
+    // Lower case prefixes
     public static final Prefix PREFIX_NAME_UPPER = new Prefix("N/");
     public static final Prefix PREFIX_PHONE_UPPER = new Prefix("P/");
     public static final Prefix PREFIX_EMAIL_UPPER = new Prefix("E/");
@@ -31,7 +36,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADD_INSURANCE_UPPER = new Prefix("AI/");
     public static final Prefix PREFIX_DELETE_INSURANCE_UPPER = new Prefix("DI/");
     public static final Prefix PREFIX_PRIORITY_UPPER = new Prefix("PR/");
-    public static final Prefix PREFIX_APPOINTMENT = new Prefix("d/");
-    public static final Prefix PREFIX_APPOINTMENT_TIME = new Prefix("t/");
-    public static final Prefix PREFIX_APPOINTMENT_VENUE = new Prefix("v/");
+    public static final Prefix PREFIX_APPOINTMENT_UPPER = new Prefix("D/");
+    public static final Prefix PREFIX_APPOINTMENT_TIME_UPPER = new Prefix("T/");
+    public static final Prefix PREFIX_APPOINTMENT_VENUE_UPPER = new Prefix("V/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -149,6 +149,7 @@ public class ParserUtil {
         requireNonNull(insurance);
 
         String trimmed = insurance.trim();
+        trimmed = trimmed.replaceAll("\\s+", " ");
 
         if (!Insurance.isValidInsuranceName(trimmed)) {
             throw new ParseException(Insurance.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/insurance/Insurance.java
+++ b/src/main/java/seedu/address/model/insurance/Insurance.java
@@ -11,7 +11,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Insurance {
 
     public static final String VALIDATION_REGEX = "\\p{Alnum}+(\\s+\\p{Alnum}+)*";
-    public static final int MAX_INSURANCE_COUNT = 5;
+    public static final int MAX_INSURANCE_COUNT = 8;
     private static final int MAX_LENGTH = 32;
 
     public static final String MESSAGE_CONSTRAINTS =
@@ -39,7 +39,7 @@ public class Insurance {
      */
     public static boolean isValidInsuranceName(String test) {
         requireNonNull(test);
-        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
+        return test.matches(VALIDATION_REGEX) && test.replaceAll("\\s", "").length() <= MAX_LENGTH;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,13 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
-
-
     public static final String MESSAGE_CONSTRAINTS = "Email should be a valid email address(i.e. local-part@domain).";
     private static final String OWASP_EMAIL_VALIDATION = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@"
             + "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}";
     public static final String VALIDATION_REGEX = OWASP_EMAIL_VALIDATION;
-
 
     public final String value;
 
@@ -67,7 +64,7 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -95,7 +95,7 @@ public class AddCommandTest {
 
     @Test
     public void execute_insuranceExceedLimit_success() throws Exception {
-        Person person = new PersonBuilder().withInsurances("1", "2", "3", "4", "5", "6", "7", "8","9").build();
+        Person person = new PersonBuilder().withInsurances("1", "2", "3", "4", "5", "6", "7", "8", "9").build();
 
         AddCommand command = new AddCommand(person);
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -95,7 +95,7 @@ public class AddCommandTest {
 
     @Test
     public void execute_insuranceExceedLimit_success() throws Exception {
-        Person person = new PersonBuilder().withInsurances("1", "2", "3", "4", "5", "6", "7", "8").build();
+        Person person = new PersonBuilder().withInsurances("1", "2", "3", "4", "5", "6", "7", "8","9").build();
 
         AddCommand command = new AddCommand(person);
 

--- a/src/test/java/seedu/address/logic/commands/InsuranceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/InsuranceCommandTest.java
@@ -210,6 +210,10 @@ public class InsuranceCommandTest {
         defaultDescriptor.setInsurancesToAdd(new Insurance(carInsurance));
         defaultDescriptor.setInsurancesToAdd(new Insurance(lifeInsurance));
         defaultDescriptor.setInsurancesToAdd(new Insurance("Great eastern insurance"));
+        defaultDescriptor.setInsurancesToAdd(new Insurance("Great western insurance"));
+        defaultDescriptor.setInsurancesToAdd(new Insurance("Great southern insurance"));
+        defaultDescriptor.setInsurancesToAdd(new Insurance("Great northern insurance"));
+        defaultDescriptor.setInsurancesToAdd(new Insurance("Great asian insurance"));
 
         InsuranceCommand command = new InsuranceCommand(secondIndex, defaultDescriptor);
 


### PR DESCRIPTION
1. Email now is case insensitive
2. Insurance now ignores contiguous spacing
3. Character count for insurance now ignores spaces
4. Insurance max count has been updated to 8
5. Uppercase version of Command word and prefixes of Appointment can be accepted by parser now
